### PR TITLE
fixing ActiveRecord

### DIFF
--- a/source/doc-pages/introduction/activerecord.md
+++ b/source/doc-pages/introduction/activerecord.md
@@ -1,5 +1,5 @@
 Many Rubyists start their journey being exposed to Rails and its favored
-object relational mapping (ORM) library, `Active Record`. `Active Record` is an
+object relational mapping (ORM) library, `ActiveRecord`. `ActiveRecord` is an
 implementation of the **Active Record** pattern. In this pattern, objects carry
 the data *and* the behavior that operates on that data.
 


### PR DESCRIPTION
Although the pattern is 'Active Record', and [even the  library is written as 'Active Record' in normal text](http://api.rubyonrails.org/classes/ActiveRecord/Base.html), when writing code--which the backticks of course denote--it should be `ActiveRecord` (without the space).
