### PR TITLE
Add tag support

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,6 +7,11 @@ set :site_url, 'http://rom-rb.org'
 set :page_title, 'Ruby Object Mapper'
 set :twitter_handle, '@rom_rb'
 
+set :people, {
+  'Don Morrison' => 'https://twitter.com/elskwid',
+  'Piotr Solnica' => 'https://twitter.com/_solnic_'
+}
+
 set :markdown_engine, :redcarpet
 set :markdown, fenced_code_blocks: true, smartypants: true
 
@@ -118,5 +123,33 @@ helpers do
 
   def twitter_page_title
     "#{page_title} via #{config.twitter_handle}"
+  end
+
+  def article_meta(article)
+    "Published on %{date} by %{author} under %{tags}" % {
+      date: article_date(article),
+      author: article_author(article),
+      tags: article_tags(article)
+    }
+  end
+
+  def article_date(article)
+    I18n.l(article.date.to_date, format: :long)
+  end
+
+  def article_author(article)
+    author_link(article.data['author'])
+  end
+
+  def article_tags(article)
+    article.tags.map { |tag| tag_link(tag) }.join(' ')
+  end
+
+  def tag_link(tag)
+    link_to(tag, tag_path(tag), class: 'tag')
+  end
+
+  def author_link(author)
+    link_to(author, config.people[author])
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -16,6 +16,7 @@ activate :blog do |blog|
   blog.layout = 'blog'
   blog.permalink = '{year}/{month}/{day}/{title}'
   blog.paginate = true
+  blog.tag_template = "blog/tag.html"
 end
 
 page 'blog/*', layout: 'blog_article'

--- a/source/blog/2014-12-31-rom-0-5-0-released.html.markdown
+++ b/source/blog/2014-12-31-rom-0-5-0-released.html.markdown
@@ -1,7 +1,7 @@
 ---
 title: ROM 0.5.0 Released
 date: 2014-12-31 21:02 UTC
-tags:
+tags: release,announcement
 author: Don Morrison
 ---
 

--- a/source/blog/_article.html.slim
+++ b/source/blog/_article.html.slim
@@ -8,7 +8,7 @@ article
     .article-author
       | Published on
       em.timestamp = I18n.l(article.date.to_date, format: :short)
-      |  by
+      | by
       em.author = article.data['author']
     .info
       == partial 'blog/article_tags.html', locals: { article: article }

--- a/source/blog/_article.html.slim
+++ b/source/blog/_article.html.slim
@@ -10,7 +10,8 @@ article
       em.timestamp = I18n.l(article.date.to_date, format: :short)
       | by
       em.author = article.data['author']
-    == partial 'blog/article_tags.html', locals: { article: article }
+    - unless header_link
+      == partial 'blog/article_tags.html', locals: { article: article }
   .article-body
     = article.body
   .article-footer

--- a/source/blog/_article.html.slim
+++ b/source/blog/_article.html.slim
@@ -10,8 +10,7 @@ article
       em.timestamp = I18n.l(article.date.to_date, format: :short)
       | by
       em.author = article.data['author']
-    .info
-      == partial 'blog/article_tags.html', locals: { article: article }
+    == partial 'blog/article_tags.html', locals: { article: article }
   .article-body
     = article.body
   .article-footer

--- a/source/blog/_article.html.slim
+++ b/source/blog/_article.html.slim
@@ -1,25 +1,23 @@
 article
-  header.page-header
+  header.page-header.clearfix
     h1
       - if header_link
         = link_to article.title, article_permalink(article)
       - else
         = article.title
-    .article-author
-      | Published on
-      em.timestamp = I18n.l(article.date.to_date, format: :short)
-      | by
-      em.author = article.data['author']
-    - unless header_link
-      == partial 'blog/article_tags.html', locals: { article: article }
+    .article-meta
+      = article_meta(article)
+  hr
   .article-body
     = article.body
   .article-footer
     hr
     .article-social
       ul.list-inline.clearfix
-        li.share-buttons.pull-left = partial 'blog/article_sharebar', locals: { article: article }
-        li.comment-link.pull-right = link_to "Leave a comment", "#{article_permalink(article)}#disqus_thread"
+        li.share-buttons.pull-left
+          = partial 'blog/article_sharebar', locals: { article: article }
+        li.comment-link.pull-right
+          = link_to "Leave a comment", "#{article_permalink(article)}#disqus_thread"
     hr
     - if comments
       .article-comments

--- a/source/blog/_article_tags.html.slim
+++ b/source/blog/_article_tags.html.slim
@@ -1,4 +1,0 @@
-- content_for(:sidebar_tags) do
-  .article-tags
-    - article.tags.each do |tag|
-      = link_to tag, tag_path(tag), class: 'btn btn-default btn-xs'

--- a/source/blog/_article_tags.html.slim
+++ b/source/blog/_article_tags.html.slim
@@ -1,4 +1,4 @@
-.article-tags
-  ul
+- content_for(:sidebar_tags) do
+  .article-tags
     - article.tags.each do |tag|
-      li = link_to tag, tag_path(tag), class: 'button tag-button'
+      = link_to tag, tag_path(tag), class: 'btn btn-default btn-xs'

--- a/source/blog/_sidebar.html.slim
+++ b/source/blog/_sidebar.html.slim
@@ -5,12 +5,8 @@
   .panel-body
     a.subscribe.btn.btn-info href="#{config.site_url}/blog/feed.xml"
       | Subscribe
-
-    - if content_for?(:sidebar_tags)
-      .sidebar-tags
-        | Published under:
-        == yield_content :sidebar_tags
-
-    - if content_for?(:sidebar)
-      .article-sidebar
-        == yield_content :sidebar
+.tag-sidebar.panel.panel-default
+  .panel-heading
+    .panel-title
+      | Browse tags
+  == partial "blog/tags"

--- a/source/blog/_sidebar.html.slim
+++ b/source/blog/_sidebar.html.slim
@@ -1,7 +1,7 @@
 .blog-sidebar.panel.panel-default
   .panel-heading
     .panel-title
-      | Welcome on ROM's blog
+      | Wherein we talk about ROM
   .panel-body
     a.btn.btn-info href="#{config.site_url}/blog/feed.xml"
       | Subscribe

--- a/source/blog/_sidebar.html.slim
+++ b/source/blog/_sidebar.html.slim
@@ -3,5 +3,14 @@
     .panel-title
       | Wherein we talk about ROM
   .panel-body
-    a.btn.btn-info href="#{config.site_url}/blog/feed.xml"
+    a.subscribe.btn.btn-info href="#{config.site_url}/blog/feed.xml"
       | Subscribe
+
+    - if content_for?(:sidebar_tags)
+      .sidebar-tags
+        | Published under:
+        == yield_content :sidebar_tags
+
+    - if content_for?(:sidebar)
+      .article-sidebar
+        == yield_content :sidebar

--- a/source/blog/_tags.html.slim
+++ b/source/blog/_tags.html.slim
@@ -1,0 +1,5 @@
+ul.blog-tags
+  - blog.tags.each do |tag, articles|
+    li
+      span class="badge" = articles.size
+      = link_to(tag, tag_path(tag))

--- a/source/blog/tag.html.slim
+++ b/source/blog/tag.html.slim
@@ -1,0 +1,13 @@
+---
+layout: "blog"
+---
+h1 #{tagname} posts
+
+ul.posts
+  - articles.each_with_index do |article, i|
+    li
+      == link_to article.title, article_permalink(article)
+      | &mdash;
+      span.date = I18n.l(article.date.to_date, format: :short)
+      | by
+      span.author = article.data['author']

--- a/source/stylesheets/blog.sass
+++ b/source/stylesheets/blog.sass
@@ -7,3 +7,19 @@
 
     em
       margin: 0 5px
+
+  .article-tags
+    a
+      margin: 5px
+
+  .blog-sidebar
+    .article-sidebar
+      margin-top: 1em
+    .subscribe
+      margin-bottom: 1em
+
+  ul.posts
+    a
+      margin-right: 0.25em
+    span
+      margin: 0.25em

--- a/source/stylesheets/blog.sass
+++ b/source/stylesheets/blog.sass
@@ -2,11 +2,8 @@
   aside
     margin-top: 20px
 
-  .article-author
+  .article-meta
     font-size: 14px
-
-    em
-      margin: 0 5px
 
   .article-tags
     a
@@ -23,3 +20,17 @@
       margin-right: 0.25em
     span
       margin: 0.25em
+
+.tag
+  @extend .btn
+  @extend .btn-default
+  @extend .btn-xs
+
+.tag + .tag
+  margin-left: 5px
+
+.blog-tags
+  @extend .list-group
+
+  li
+    @extend .list-group-item


### PR DESCRIPTION
I thought I'd give tag support a shot. Here we have basic support for tagging articles and the creation of the tag pages using the included template when the site is built. 

Tag pages look like this:

![rom blog 2014-12-31 18-09-38](https://cloud.githubusercontent.com/assets/9002/5591514/37756432-9118-11e4-9404-901b5141d2a7.png)
![rom blog 2014-12-31 18-09-50](https://cloud.githubusercontent.com/assets/9002/5591515/3ec547ca-9118-11e4-8c27-da3a0766d5e6.png)

The tags are displayed in the sidebar when you are viewing an article:

![rom blog rom 0 5 0 released 2014-12-31 18-10-28](https://cloud.githubusercontent.com/assets/9002/5591516/55df3f10-9118-11e4-8b13-53e5d1f0225c.png)

I kinda like that, it keeps the article nice and clean, but give some additional context. This happens via a `content_for(:sidebar_tags)` block. I also added a `content_for(:sidebar)` block for other stuff we may want to shove in there.

And in case you missed it, the sidebar title is changed:

![rom blog 2014-12-31 18-12-32](https://cloud.githubusercontent.com/assets/9002/5591522/a45a9c5c-9118-11e4-8c8d-7a012ae67def.png)

:fireworks: Happy New Year! :fireworks: 