### PR TITLE
Re-order main nav thematically

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -94,7 +94,7 @@ helpers do
   def api_docs_nav
     html = ""
 
-    html << link_to("API Docs <span class='caret'/>", "#",
+    html << link_to("API Reference <span class='caret'/>", "#",
                     class: "dropdown-toggle",
                     role: "button", data: { toggle: "dropdown" })
 

--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -31,11 +31,11 @@ html
             .container
               a.navbar-brand href="/" Ruby Object Mapper
               ul.nav.navbar-nav
-                = nav_link("/status", "Status")
                 = nav_link("/introduction", "Introduction")
                 = nav_link("/tutorials", "Tutorials")
                 li.dropdown == api_docs_nav
                 = nav_link("/blog", "Blog")
+                = nav_link("/status", "Status")
               .social
                 .github
                   iframe src="http://ghbtns.com/github-btn.html?user=rom-rb&repo=rom&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"

--- a/source/status.html.slim
+++ b/source/status.html.slim
@@ -1,15 +1,16 @@
 ---
 title: Ruby Object Mapper - Status
+slug: "/status"
 ---
 
 h1 ROM Project Status
 
 p
-  | ROM consists of the core rom gem along with rom-rails, for Rails integration,
-    and several adapter gems.
+  | The ROM ecosystem consists of the core rom gem along with rom-rails,
+    for Rails integration, and various adapter gems.
 
 p
-  | With all these projects it can be difficult to keep up on the status of
+  | With so many projects, it can be difficult to keep up on the status of
     each one. Below is a break-down for each rom-related project, the current
     stable released version, and the build status for the master branch.
 


### PR DESCRIPTION
From left to right, the nav now goes from documentation to news and status updates.

The 'API Docs' link is renamed to 'API Reference'.

Also fixes a bug where the 'Status' link was not correctly highlighted with an active class when browsing to the status page.

And some minor edits to improve the readability of the status page.