### PR TITLE
Fix associates syntax

### DIFF
--- a/source/doc-pages/guides/adapters/sql.md
+++ b/source/doc-pages/guides/adapters/sql.md
@@ -264,7 +264,7 @@ class CreateTask < ROM::Commands::Create[:sql]
   register_as :create
   result :one
 
-  associates :user, key: { user_id: :id }
+  associates :user, key: [:user_id, :id]
 end
 
 class CreateUser < ROM::Commands::Create[:sql]

--- a/source/doc-pages/guides/adapters/sql.md
+++ b/source/doc-pages/guides/adapters/sql.md
@@ -230,7 +230,7 @@ class CreateTask < ROM::Commands::Create[:sql]
   register_as :create
   result :one
 
-  associates :user, key: { user_id: :id }
+  associates :user, key: [:user_id, :id]
 end
 
 class CreateUser < ROM::Commands::Create[:sql]


### PR DESCRIPTION
The `rom-sql` `associates` plugin requires `key` to be an array, not a hash.

The comments in the source code reflect this correctly: https://github.com/rom-rb/rom-sql/blob/master/lib/rom/sql/plugin/associates.rb#L49