### PR TITLE
Hide empty errors arrays in to-do app task forms

### DIFF
--- a/source/doc-pages/tutorials/todo-app-with-rails.md
+++ b/source/doc-pages/tutorials/todo-app-with-rails.md
@@ -591,7 +591,7 @@ Creating a view template for this form is easily done with the built-in Rails ta
 # app/views/tasks/new.html.erb
 
 <%= form_for task do |t| %>
-  <%= task.errors.full_messages if task.errors %>
+  <%= task.errors.full_messages if task.errors.present? %>
   <%= t.text_field :title %>
   <%= t.select :is_completed, [['Completed', true], ['Active', false]] %>
   <%= t.submit %>


### PR DESCRIPTION
Without checking for `tasks.present?`, `full_errors` will show as an empty array (`[]`) on the task form, even when the task is fully valid.

I was confused for a moment by this, thinking it might have been some quirk of ROM's integration with Rails. Hiding the empty array makes the form appear as expected.