### PR TITLE
Fix command example in Mappers Guide

### DIFF
--- a/source/doc-pages/guides/basics/mappers.md
+++ b/source/doc-pages/guides/basics/mappers.md
@@ -99,11 +99,16 @@ users.map_with(:entity).to_a
 Mappers can also be used to convert tuples that are returned from ROM [commands](commands).
 
 ```ruby
-create_user = ROM.env.command(:users).create
-create_user.call id: 3, name: 'jack', email: 'jack@doo.org'
+rom = ROM.env
+
+rom.command(:users).create.call(
+  id: 3, name: 'jack', email: 'jack@doo.org'
+)
 # { id: 3, name: 'jack', email: 'jack@doo.org' }
 
-create_user.as(:entity).create id: 4, name: 'joffrey', email: 'joffrey@doo.org'
+rom.command(:users).as(:entity).create(
+  id: 4, name: 'joffrey', email: 'joffrey@doo.org'
+)
 # <User @id=4, @name='jeff', @email='joffrey@doo.org'>
 ```
 


### PR DESCRIPTION
The chain order seems to matter.

    # This works
    ROM.env.command(:users).as(:user).create.call

    # This raises ROM::MapperMissingError
    ROM.env.command(:users).create.as(:user).call

Maybe this is a regression that can be fixed, but in the meantime
the examples in the documentation should be updated.