### PR TITLE
Fix setup guide code examples

### DIFF
--- a/source/doc-pages/guides/basics/setup.md
+++ b/source/doc-pages/guides/basics/setup.md
@@ -54,7 +54,7 @@ ROM.setup(:memory)
 class Users < ROM::Relation[:memory]
 end
 
-rom.register_relation(Users)
+ROM.register_relation(Users)
 
 ROM.finalize
 ```
@@ -80,8 +80,8 @@ class Tasks < ROM::Relation[:yaml]
   gateway :other
 end
 
-rom.register_relation(Users)
-rom.register_relation(Tasks)
+ROM.register_relation(Users)
+ROM.register_relation(Tasks)
 
 ROM.finalize
 ```


### PR DESCRIPTION
Guide refers to calling `#register_relation` on `rom` object that doesn't exist yet. They should be called on `ROM`.

... maybe I'm wrong about this. I just don't see where `rom` comes from. Also, maybe you just want to have `ROM.use :auto_registration` in all the examples?