### PR TITLE
Fix 404 on the big button (/introduction doesn't exist)

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -8,7 +8,7 @@
   p
     ul class="list-inline"
       li
-        a href="/introduction" class="btn btn-primary btn-lg" Learn more
+        a href="/learn" class="btn btn-primary btn-lg" Learn more
       li
         a href="https://salt.bountysource.com/teams/rom-rb" class="btn btn-success btn-lg" Support ROM!
         a href="/blog/2015/08/04/sustainable-development-campaign" Read the announcement about our campaign


### PR DESCRIPTION
Looks like the `/introduction` page doesn't exist or something else is wrong with the build of the site:
![image](https://cloud.githubusercontent.com/assets/847583/12375383/c1b663d4-bc74-11e5-94db-7df415f20c58.png)

This should at least prevent the giant "Learn more" button from going to a 404 page!