### PR TITLE
Next in block style

### DIFF
--- a/source/learn/adapters/adapter/cassandra.md
+++ b/source/learn/adapters/adapter/cassandra.md
@@ -26,7 +26,7 @@ The adapter uses [datastax ruby driver][ruby driver] under the hood. You can fin
 
 ## Defining Relations
 
-To define a Cassandra relation follow [the standard way of defining relations](http://rom-rb.org/learn/read/simple/) in ROM.
+To define a Cassandra relation follow [the standard way of defining relations](http://rom-rb.org/learn/reading/simple-objects) in ROM.
 
 The only specifics is that you're expected to set both the keyspace and table name explicitly, using the *dot notation*:
 

--- a/source/learn/setup/block-style.html.md
+++ b/source/learn/setup/block-style.html.md
@@ -93,4 +93,4 @@ end
 
 ## Next
 
-Learn [how to read](/learn/read/) by defining Repositories and Relations
+Learn [how to read](/learn/reading/) by defining Repositories and Relations


### PR DESCRIPTION
Fixed link next in learning/block-style. Spotted the same problem in Cassanda adapter page but i'm not sure if its ok just to apply this fix or the whole page needs to be rewritten, thats why I put it in separate commit