### PR TITLE
Rails Setup - ROM.container

### DIFF
--- a/source/learn/setup/rails.html.md
+++ b/source/learn/setup/rails.html.md
@@ -66,10 +66,10 @@ After that, you have access to following tasks:
 
 ## Accessing Container
 
-In Rails environment ROM container is accessible via `ROM.container`:
+In Rails environment ROM container is accessible via `ROM.env`:
 
 ``` ruby
-ROM.container # returns the container
+ROM.env # returns the container
 ```
 
 Accessing global container directly is considered as a bad practice. The
@@ -95,7 +95,7 @@ class Users < ROM::Relation[:sql]
 end
 
 # access registered relation via container
-ROM.container.relations[:users]
+ROM.env.relations[:users]
 ```
 
 ## Defining Commands
@@ -112,7 +112,7 @@ class CreateUser < ROM::Commands::Create[:sql]
 end
 
 # access registered relation via container
-ROM.container.commands[:users][:create]
+ROM.env.commands[:users][:create]
 ```
 
 ## Defining Custom Mappers


### PR DESCRIPTION
So first PR to make rails setup docks usable #123 . Apparently accessing `ROM.container` does not return relations, commands etc. defined inside `app/` to access them you should use `ROM.env` so here's the fix for this issue. 