### PR TITLE
Calling 'use(:macros)' is no longer necessary. Macros are enabled by default.

### DIFF
--- a/source/learn/advanced/commands.html.md
+++ b/source/learn/advanced/commands.html.md
@@ -150,8 +150,6 @@ require 'rom-sql'
 
 # Assumes a database with a users table
 rom_container = ROM.container(:sql, 'sqlite::memory') do |rom|
-  rom.use :macros
-
   rom.relation(:users) do
     def by_id(id)
       restrict(id: id)

--- a/source/learn/advanced/flat-style.html.md
+++ b/source/learn/advanced/flat-style.html.md
@@ -35,14 +35,12 @@ ROM components need to be registered with the ROM environment in order to be
 used.
 
 The `:macros` plugin handles this behind the scenes for you whenever you use the
-DSL to declare a ROM component. Call `use(:macros)` to enable the plugin:
+DSL to declare a ROM component. As of version 1.0.0 it is enabled by default:
 
 ```ruby
 configuration = ROM::Configuration.new(:memory, 'memory://test')
 
 # Anything after this line will be automatically registered
-configuration.use :macros
-
 # Declare Relations, Commands, and Mappers here
 ```
 

--- a/source/learn/reading/simple-objects.html.md
+++ b/source/learn/reading/simple-objects.html.md
@@ -16,8 +16,6 @@ override the default, just call `Configuration#relation`.
 
 ```ruby
 rom_container = ROM.container(:sql, 'sqlite::memory') do |rom|
-  rom.use :macros
-
   rom.relation(:users)
 
   rom.relation(:tasks) do
@@ -139,8 +137,6 @@ This short example demonstrates using selector methods, #one, and #to_a.
 require 'rom-repository'
 
 rom_container = ROM.container(:sql, 'sqlite::memory') do |rom|
-  rom.use :macros
-
   rom.relation(:users)
 end
 
@@ -195,8 +191,6 @@ require 'dry-data'
 require 'rom-repository'
 
 rom_container = ROM.container(:sql, 'sqlite::memory') do |rom|
-  rom.use :macros
-
   rom.relation(:locations)
 end
 

--- a/source/learn/setup/block-style.html.md
+++ b/source/learn/setup/block-style.html.md
@@ -82,12 +82,13 @@ Both block and flat style support calling `use` on the `ROM::Configuration`
 object to activate plugins for that configuration.
 
 Currently, the only bundled plugin is `:macros`, which provides the DSL for
-specifying your relations, commands, and mappers.
+specifying your relations, commands, and mappers. As of version 1.0.0 the
+`:macros`-plugin is included by default.
 
 ```ruby
 ROM.container(:sql, 'sqlite::memory') do |rom|
    # rom is a ROM::Configuration
-   rom.use :macros
+   rom.use :some_plugin_name
 end
 ```
 


### PR DESCRIPTION
So remove it from the learning section as its somewhat confusing for beginners if the example code raises warnings.

Besides, I have seen that the second deprecation warning I got is already fixed in the master branch but the website still shows it in the example code (use Repository instead of Repository::Base) so please consider updating the rom-rb.org website.