### PR TITLE
Topic Learn / Adapters / SQL # Section Migrations (Rakefile)

### DIFF
--- a/source/learn/adapters/sql.html.md
+++ b/source/learn/adapters/sql.html.md
@@ -316,11 +316,13 @@ sets up ROM.
 ``` ruby
 # your rakefile
 
+require 'rom/sql'
 require 'rom/sql/rake_task'
 
 namespace :db do
   task :setup do
     # your ROM setup code
+    @gateway = ROM.container(:sql, 'postgres://localhost/rom')
   end
 end
 ```


### PR DESCRIPTION
Added an example setup to clarify that you need to assign something to @gateway and need to require 'rom/sql' as well as otherwise an 'NameError: uninitialized constant ROM::SQL::Gateway' is raised