### PR TITLE
Fix syntax highlight in flat-style.html.md

### DIFF
--- a/source/learn/advanced/flat-style.html.md
+++ b/source/learn/advanced/flat-style.html.md
@@ -103,7 +103,7 @@ requirement.
 While the DSL syntax is often convenient, Relations can also be defined with a
 class extending `ROM::Relation` from the appropriate adapter.
 
-```Ruby
+```ruby
 # Defines a Users relation for the SQL adapter
 class Users < ROM::Relation[:sql]
 


### PR DESCRIPTION
The site is highlighting the code as plaintext, and not as ruby code because of the capital letter. It's in the url http://rom-rb.org/learn/advanced/flat-style/