### PR TITLE
Fix small typo in combing relation example

### DIFF
--- a/source/learn/advanced/combine.html.md
+++ b/source/learn/advanced/combine.html.md
@@ -21,7 +21,7 @@ class Tasks < ROM::Relation[:memory]
 end
 
 
-rom_container = ROM.container(:sql) do |rom|
+rom_container = ROM.container(:memory) do |rom|
   rom.register_relation(Users, Tasks)
 end
 


### PR DESCRIPTION
In the example, the container is setup as :sql but the rest of the example uses :memory
