### PR TITLE
Added a section on running alongside ActiveRecord

### DIFF
--- a/source/learn/getting-started/rails-setup.html.md
+++ b/source/learn/getting-started/rails-setup.html.md
@@ -139,7 +139,7 @@ end
 ## Running alongside ActiveRecord
 
 There might be some cases where you will want to run ROM alongside ActiveRecord.
-Since ROM.rb is designed to work independently, you will need to take few additional steps.
+Since ROM is designed to work independently, you will need to take few additional steps.
 
 ROM creates it's own connections and Rails above version 5 won't allow you to drop the 
 database since there are active connections on it.


### PR DESCRIPTION
Hello! Referring to this issue https://github.com/rom-rb/rom-rails/issues/65 I created a documentation section on how to run ROM alongside with ActiveRecord. 

There is a reference to monkey patch and without it rake db:migrate tasks do not work with new tables. It makes me cringe, but I am open to suggestions on how to improve this section. 