### PR TITLE
Fix typo in docs/learn/core/schemas/index.html

### DIFF
--- a/docs/learn/core/schemas/index.html
+++ b/docs/learn/core/schemas/index.html
@@ -102,7 +102,7 @@ useful for adapters, or anything that may need to introspect relation schemas.</
 <span class="k">end</span>
 </code></pre>
 
-<p>Here we defined a <code>:namespace</code> meta-information, that can be used accessed via
+<p>Here we defined a <code>:namespace</code> meta-information, that can be accessed via
 <code>:name</code> type:</p>
 <pre class="syntax ruby"><code><span class="no">Users</span><span class="p">.</span><span class="nf">schema</span><span class="p">[</span><span class="ss">:name</span><span class="p">].</span><span class="nf">meta</span><span class="p">[</span><span class="ss">:namespace</span><span class="p">]</span> <span class="c1"># 'details'</span>
 </code></pre>


### PR DESCRIPTION
> Here we defined a :namespace meta-information, that can be ~~used~~ accessed via :name type: