### PR TITLE
db.rb => db.rake

### DIFF
--- a/source/learn/getting-started/rails-setup.html.md
+++ b/source/learn/getting-started/rails-setup.html.md
@@ -145,7 +145,7 @@ ROM creates it's own connections and Rails above version 5 won't allow you to dr
 database since there are active connections on it.
 
 ``` ruby
-# lib/tasks/db.rb
+# lib/tasks/db.rake
 task :remove_rom_connection => [:environment] do
   ROM.env && ROM.env.disconnect
 end


### PR DESCRIPTION
Putting code in `lib/tasks/db.rb` doesn't do anything at all, it should be named `.rake`.
