### PR TITLE
add missing links

### DIFF
--- a/source/learn/repositories/index.html.md
+++ b/source/learn/repositories/index.html.md
@@ -14,3 +14,6 @@ In this section you can learn how to work with ROM repositories.
 * [Quick Start](/learn/repositories/quick-start)
 * [Reading Simple Objects](/learn/repositories/reading-simple-objects)
 * [Reading Aggregates](/learn/repositories/reading-aggregates)
+* [Composing Relations](/learn/repositories/composing-relations)
+* [Changesets](/learn/repositories/changesets)
+* [Writing Aggregates](/learn/repositories/writing-aggregates)


### PR DESCRIPTION
Some links in the "Repositories" section are displayed in the sidebar but not on the index page. This commit adds those links.