### PR TITLE
Fix method to create container in "How to Build a ROM Adapter"

### DIFF
--- a/source/learn/advanced/how-to-build-an-adapter.html.md
+++ b/source/learn/advanced/how-to-build-an-adapter.html.md
@@ -121,7 +121,7 @@ end
 
 configuration.register_relation(Users)
 
-rom = ROM.create_container(configuration)
+rom = ROM.container(configuration)
 
 users = rom.gateways[:default].dataset(:users)
 


### PR DESCRIPTION
Change method from `ROM.create_container` to `ROM.container`.

```ruby
rom = ROM.create_container(configuration)
# NoMethodError: undefined method 'create_container' for ROM:Module

rom = ROM.container(configuration)
=> #<ROM::Container gateways={:default=>#<ROM::Datastore::Gateway:0x0000000286df10 @datasets={:users=>[]}>} relations=#<ROM::RelationRegistry elements={:users=>#<Users dataset=[]>}> mappers=#<ROM::Registry elements={}> commands=#<ROM::Registry elements={}>>
```