### PR TITLE
Update migrations path

### DIFF
--- a/docs/learn/sql/migrations/index.html
+++ b/docs/learn/sql/migrations/index.html
@@ -25,7 +25,7 @@ sets up ROM.</p>
 
 <ul>
 <li><code>rake db:create_migration[create_users]</code> - create migration file under
-<code>db/migrations</code></li>
+<code>db/migrate</code></li>
 <li><code>rake db:migrate</code> - runs migrations</li>
 <li><code>rake db:clean</code> - removes all tables</li>
 <li><code>rake db:reset</code> - removes all tables and re-runs migrations</li>

--- a/source/learn/sql/migrations.html.md
+++ b/source/learn/sql/migrations.html.md
@@ -26,7 +26,7 @@ end
 The following tasks are available:
 
 * `rake db:create_migration[create_users]` - create migration file under
-  `db/migrations`
+  `db/migrate`
 * `rake db:migrate` - runs migrations
 * `rake db:clean` - removes all tables
 * `rake db:reset` - removes all tables and re-runs migrations


### PR DESCRIPTION
By default migrations are saved in '/db/migrate' not into '/db/migrations'.