### PR TITLE
Update changeset documention on how to create them

### DIFF
--- a/source/learn/repositories/changeset-transactions.html.md
+++ b/source/learn/repositories/changeset-transactions.html.md
@@ -60,7 +60,7 @@ user_repo = UserRepo.new(rom)
 task = task_repo.transaction do
   user = user_repo.create(name: 'Jane')
 
-  new_task = task_repo.changeset(title: 'Task One').associate(user)
+  new_task = task_repo.tasks.changeset(:create, title: 'Task One').associate(user)
 
   task_repo.create(new_task)
 end

--- a/source/learn/repositories/changesets.html.md
+++ b/source/learn/repositories/changesets.html.md
@@ -35,7 +35,7 @@ user_repo = UserRepo.new(rom)
 
 user = user_repo.create(name: 'Jane', email: 'jane@doe.org')
 
-changeset = user_repo.changeset(user.id, name: 'Jane Doe')
+changeset = user_repo.users.changeset(:update, user.id, name: 'Jane Doe')
 
 changeset.diff? # true
 changeset.diff # {:name=>"Jane Doe"}
@@ -54,7 +54,7 @@ Repositories **will not execute an update command** if there's no diff between
 the original tuple and the new one, i.e.:
 
 ``` ruby
-changeset = user_repo.changeset(user.id, email: 'jane@doe.org')
+changeset = user_repo.users.changeset(:update, user.id, email: 'jane@doe.org')
 
 changeset.diff? # false
 
@@ -93,7 +93,7 @@ Then we can ask the user repo for our changeset:
 ``` ruby
 user_data = { name: 'Jane', address: { city: 'NYC', street: 'Street 1' } }
 
-changeset = user_repo.changeset(NewUserChangeset).data(user_data)
+changeset = user_repo.users.changeset(NewUserChangeset).data(user_data)
 
 changeset.to_h
 # { name: 'Jane', address_city: 'NYC', address_street: 'Street 1' }
@@ -115,7 +115,7 @@ end
 
 user_data = { name: 'Jane' }
 
-changeset = user_repo.changeset(NewUserChangeset).data(user_data)
+changeset = user_repo.users.changeset(NewUserChangeset).data(user_data)
 
 changeset.to_h
 # { name: 'Jane', created_on: <Date: 2017-01-21 ((2457775j,0s,0n),+0s,2299161j)> }
@@ -135,8 +135,8 @@ additional mappings at run-time without having to use a custom changeset class.
 To do this simply use `Changeset#map` method:
 
 ``` ruby
-changeset = user_repo
-  .changeset(name: 'Joe', email: 'joe@doe.org')
+changeset = user_repo.users
+  .changeset(:create, name: 'Joe', email: 'joe@doe.org')
   .map(:add_timestamps)
 
 user_repo.create(changeset)
@@ -149,7 +149,7 @@ Changesets can be committed without the need to use repository command methods. 
 raw data returned from your database:
 
 ``` ruby
-new_user = repo.changeset(name: 'Jane')
+new_user = repo.users.changeset(:create, name: 'Jane')
 => #<ROM::Changeset::Create relation=ROM::Relation::Name(users) data={:name=>"Jane"}>
 
 repo.create(new_user)

--- a/source/learn/repositories/custom-changesets.html.md
+++ b/source/learn/repositories/custom-changesets.html.md
@@ -33,7 +33,7 @@ end
 Now we can easily use this changeset with a user repository:
 
 ``` ruby
-new_user = user_repo.changeset(NewUserChangeset).data(name: 'Jane')
+new_user = user_repo.users.changeset(NewUserChangeset).data(name: 'Jane')
 
 user_repo.create(new_user)
 # => #<ROM::Struct[User] id=1 name="Jane" access_token="b9dd175aec90758b0841d09e4947724e">
@@ -63,12 +63,12 @@ end
 Now we can ask specific root repositories for instances of this changeset:
 
 ``` ruby
-new_user = user_repo.changeset(NewUserChangeset).data(name: 'Jane')
+new_user = user_repo.users.changeset(NewUserChangeset).data(name: 'Jane')
 
 user_repo.create(new_user)
 # => #<ROM::Struct[User] id=1 name="Jane" access_token="b9dd175aec90758b0841d09e4947724e">
 
-new_admin = admin_repo.changeset(NewUserChangeset).data(name: 'Jane')
+new_admin = admin_repo.users.changeset(NewUserChangeset).data(name: 'Jane')
 
 admin_repo.create(new_admin)
 # => #<ROM::Struct[Admin] id=1 name="Jane" access_token="b9dd175aec90758b0841d09e4947724e">
@@ -98,7 +98,7 @@ Now we can get our custom changeset and restrict its relation by its primary key
 
 ``` ruby
 user = user_repo.create(name: "Jane")
-changeset = user_repo.changeset(UpdateUserChangeset).by_pk(user.id)
+changeset = user_repo.users.changeset(UpdateUserChangeset).by_pk(user.id)
 
 user_repo.update(changeset)
 # => #<ROM::Struct[User] id=1 name="Jane" access_token="b9dd175aec90758b0841d09e4947724e">
@@ -108,7 +108,7 @@ You can also pass data to the restriction method:
 
 ``` ruby
 user = user_repo.create(name: "Jane")
-changeset = user_repo.changeset(UpdateUserChangeset).by_pk(user.id, name: "Jane Doe")
+changeset = user_repo.users.changeset(UpdateUserChangeset).by_pk(user.id, name: "Jane Doe")
 
 user_repo.update(changeset)
 # => #<ROM::Struct[User] id=1 name="Jane Doe" access_token="b9dd175aec90758b0841d09e4947724e">
@@ -129,7 +129,7 @@ class NewUserChangeset < ROM::Changeset::Create
   end
 end
 
-new_user = user_repo.
+new_user = user_repo.users
   changeset(NewUserChangeset).
   with(token_generator: SecureRandom.method(:hex).
   data(name: 'Jane')

--- a/source/learn/repositories/sessions.html.md
+++ b/source/learn/repositories/sessions.html.md
@@ -10,7 +10,7 @@ a session object to the block and queues your changesets to be persisted in a tr
 ## Saving a single changeset
 
 ``` ruby
-changeset = user_repo.changeset(name: 'Jane')
+changeset = user_repo.users.changeset(:create, name: 'Jane')
 
 user_repo.session do |s|
   s.add(changeset)
@@ -22,8 +22,8 @@ end
 If you configured associations in your schemas, you can associate changesets easily:
 
 ``` ruby
-user_changeset = user_repo.changeset(name: 'Jane')
-task_changeset = task_repo.changeset(title: 'Task 1')
+user_changeset = user_repo.users.changeset(:create, name: 'Jane')
+task_changeset = task_repo.tasks.changeset(:create, title: 'Task 1')
 
 user_repo.session do |s|
   s.add(user_changeset.associate(task_changeset, :user))
@@ -37,8 +37,8 @@ You can use all changeset types within the same session, let's say we want updat
 ``` ruby
 user = user_repo.fetch(1)
 
-user_changeset = user_repo.changeset(task_count: user.task_count + 1)
-new_task_changeset = task_repo.changeset(title: 'Another task')
+user_changeset = user_repo.users.changeset(:create, task_count: user.task_count + 1)
+new_task_changeset = task_repo.tasks.changeset(:create, title: 'Another task')
 
 user_repo.session do |s|
   s.add(new_task_changeset.associate(user, :user)


### PR DESCRIPTION
Updated changeset documentation for `rom 4` having to pass the type of chageset as first argument and that repo itself do not have access to changeset 