### PR TITLE
auto_registration('/path/to/lib') assumptions

### DIFF
--- a/docs/learn/advanced/explicit-setup/index.html
+++ b/docs/learn/advanced/explicit-setup/index.html
@@ -61,9 +61,11 @@ mappers from <code>&lt;base&gt;/mappers</code>.</p>
 <p>By default, auto-registration assumes that the directory structure reflects your module/class
 organization, for example:</p>
 <pre class="syntax ruby"><code><span class="c1"># lib/relations/users.rb</span>
-<span class="k">module</span> <span class="nn">Relations</span>
-  <span class="k">class</span> <span class="nc">Users</span> <span class="o">&lt;</span> <span class="no">ROM</span><span class="o">::</span><span class="no">Relation</span><span class="p">[</span><span class="ss">:sql</span><span class="p">]</span>
-    <span class="n">schema</span><span class="p">(</span><span class="ss">infer: </span><span class="kp">true</span><span class="p">)</span>
+<span class="k">module</span> <span class="nn">Lib</span>
+  <span class="k">module</span> <span class="nn">Relations</span>
+    <span class="k">class</span> <span class="nc">Users</span> <span class="o">&lt;</span> <span class="no">ROM</span><span class="o">::</span><span class="no">Relation</span><span class="p">[</span><span class="ss">:sql</span><span class="p">]</span>
+      <span class="n">schema</span><span class="p">(</span><span class="ss">infer: </span><span class="kp">true</span><span class="p">)</span>
+    <span class="k">end</span>
   <span class="k">end</span>
 <span class="k">end</span>
 

--- a/source/learn/advanced/explicit-setup.html.md
+++ b/source/learn/advanced/explicit-setup.html.md
@@ -69,9 +69,11 @@ organization, for example:
 
 ``` ruby
 # lib/relations/users.rb
-module Relations
-  class Users < ROM::Relation[:sql]
-    schema(infer: true)
+module Lib
+  module Relations
+    class Users < ROM::Relation[:sql]
+      schema(infer: true)
+    end
   end
 end
 


### PR DESCRIPTION
I recently started my first project that uses rom-rb and came across the following logic that I think isn't made clear in the current documentation, unless I'm mistaken.

When using
```ruby
config.auto_registration('path/to/lib')
```
ROM assumes `lib` to be part of the namespace, so relations should be declared like this:

```ruby
module Lib
  module Relations
    class MyRelation < ROM::Relation[:sql]
      schema(infer: true)
    end
  end
end
```
So:
```ruby
configuration.auto_registration('/path/to/<base>')
# does this:
configuration.auto_registration('/path/to/<base>', namespace: '<Base>')
```