### PR TITLE
Fix rom-rb/rom#459 - example missing primary keys

### DIFF
--- a/source/4.0/learn/core/associations.html.md
+++ b/source/4.0/learn/core/associations.html.md
@@ -45,7 +45,9 @@ class Users < ROM::Relation[:memory]
   schema do
     attribute :id, Types::Int
     attribute :name, Types::String
-
+    
+    primary_key :id
+    
     associations do
       has_many :tasks, combine_key: :user_id, override: true, view: :for_users
     end
@@ -57,6 +59,8 @@ class Tasks < ROM::Relation[:memory]
     attribute :id, Types::Int
     attribute :user_id, Types::Int
     attribute :title, Types::String
+    
+    primary_key :id
   end
 
   def for_users(_assoc, users)


### PR DESCRIPTION
Example failed because primary keys were not set, so when `ROM::Associations::OneToMany#source_key` was called the combined `tasks` relation had a meta hash that looked like:

```
{:keys=>{nil=>:user_id},
      :combine_type=>:many,
      :combine_name=>:tasks,
      :dataset=>:tasks,
      :alias=>:tasks,
      :struct_namespace=>ROM::Struct,
      :model=>false}
``` 
A suggestion would be to raise an exception in associations that use a nil primary key? It would definitely help the debugging process.