### PR TITLE
Fix example for simple objects for ROM 4

### DIFF
--- a/source/4.0/learn/repositories/reading-simple-objects.html.md
+++ b/source/4.0/learn/repositories/reading-simple-objects.html.md
@@ -9,7 +9,16 @@ your app:
 
 ```ruby
 # Assuming a database with tables 'users' and 'projects'
-rom = ROM.container(:sql, 'sqlite::memory')
+rom = ROM.container(:sql, 'sqlite::memory') do |config|
+  config.relation(:users) do
+    schema(infer: true)
+    auto_struct true
+  end
+  config.relation(:projects) do
+    schema(infer: true)
+    auto_struct true
+  end
+end
 
 # Perhaps one Repo to handle users
 class UserRepo < ROM::Repository[:users]


### PR DESCRIPTION
Example for reading objects from repositories (which is linked right from "Getting Started" is kind of misleading, as it does not include registering relations. As a result, even copying it leads to errors.

See gist: https://gist.github.com/katafrakt/c7a35c70f09dc267dfba1876e9ef6d7d

This fixes it for 4.0. Should the fix be applied to 3.0 too?