### PR TITLE
Fix slashes in class names in anchored links

### DIFF
--- a/lib/markdown_renderer.rb
+++ b/lib/markdown_renderer.rb
@@ -35,8 +35,8 @@ class MarkdownRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
 
   def link(link, title, content)
     if content.start_with?('api::')
-      _, project, klass = content.split('::')
-      link_to_api(project, klass, link)
+      _, project, path = content.split('::')
+      link_to_api(project, path, target)
     elsif link['%{version}']
       super(link % { version: scope.version }, title, content)
     else
@@ -44,23 +44,18 @@ class MarkdownRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
     end
   end
 
-  def link_to_api(project, klass, meth)
-    if meth.start_with?('#') || meth.start_with?('.')
-      content = "#{klass}#{meth}"
-      path = klass.gsub('::', '/') if klass
+  def link_to_api(project, path, target)
+    klass = path.gsub('/', '::') if path
+
+    if target.start_with?('#') || target.start_with?('.')
+      content = "#{klass}#{target}"
 
       link(
-        config.api_anchor_url_template % { project: project, path: path, anchor: anchor(meth) },
+        config.api_anchor_url_template % { project: project, path: path, anchor: anchor(target) },
         nil, content
       )
     else
-      if klass
-        content = "ROM::#{klass}::#{meth}"
-        path = "#{klass.gsub('::', '/')}/#{meth}"
-      else
-        content = "ROM::#{meth}"
-        path = meth
-      end
+      content = ['ROM', *klass, target].join('::')
 
       link(
         config.api_url_template % { project: project, path: path },


### PR DESCRIPTION
When the link would have an anchor (referencing a certain method) and class name would be nested in a namespace, it would be displayed with slashes instead of `::`. An example can be seen on the [*Reading aggregates*](http://rom-rb.org/4.0/learn/repositories/reading-aggregates/) page:

<img width="921" alt="screen shot 2017-12-03 at 22 01 49" src="https://user-images.githubusercontent.com/795488/33529782-9a377180-d875-11e7-9175-998a53dd25ec.png">

I updated the link rendering logic with the notion that the content of links are in fact paths, not classes (maybe they were classes originally and the logic got outdated), and converted those paths into class names for link content.