### PR TITLE
Various documentation corrections

### DIFF
--- a/source/4.0/learn/getting-started/core-concepts.html.md
+++ b/source/4.0/learn/getting-started/core-concepts.html.md
@@ -36,7 +36,7 @@ is a basic explanation of each component.
             calls into the appropriate repository and asks for an entity
         
 **Step 2.** The Repository accepts the request and combines all of the
-            related associations together to create a datastore specific query
+            related associations together to create a datastore-specific query
             for the data
         
 **Step 3.** Once a relation has been composed of all needed restrictions or 
@@ -61,7 +61,7 @@ in order to modify the stored data.
 **Step 7.** Application Domain has a need to update an entity.
 
 **Step 8.** The repository, accepting either an entity object or a raw `Hash`
-            representing the entity configures either a changeset or direct
+            representing the entity, configures either a changeset or direct
             command on relation to make changes to the datastore.
 
 **Step 8.1.** Before the Changeset passes itself to the underlying command, you

--- a/source/4.0/learn/repositories/reading-aggregates.html.md
+++ b/source/4.0/learn/repositories/reading-aggregates.html.md
@@ -19,7 +19,7 @@ however, in the early days of every project, using canonical associations is all
 you need, so let's start with that!
 
 We're going to define `:users` that have many `:tasks`. To keep things simpler
-let's define relations using [block-style setup](/%{version}/learn/getting-started/block-style-setup):
+let's define relations using [block-style setup](/%{version}/learn/getting-started/setup-dsl):
 
 ``` ruby
 require 'rom'

--- a/source/4.0/learn/sql/associations.html.md
+++ b/source/4.0/learn/sql/associations.html.md
@@ -20,7 +20,7 @@ end
 ```
 
 > #### Naming convention
-> This method is a shortcut for `belongs_to :users, as: :user`
+> This method is a shortcut for `many_to_one :users, as: :user`
 
 ## has_many (one-to-many)
 

--- a/source/4.0/learn/sql/index.html.md
+++ b/source/4.0/learn/sql/index.html.md
@@ -40,7 +40,7 @@ tracker](https://github.com/rom-rb/rom-rb.org/issues).
   isn't documented or requires more information, please click the  "Provide
   Feedback" buttons at the bottom of the pages and let us know. In the mean time
   you may need to look towards
-  [Sequels](http://sequel.jeremyevans.net/documentation.html) Databases &
+  [Sequel's](http://sequel.jeremyevans.net/documentation.html) Databases &
   Datasets documentation for further guidance.
 ^
 
@@ -67,7 +67,7 @@ for immediate use via the `:sql` identifier.
 
 ^
   Each database type requires a separate driver gem to also be installed. 
-  Be sure to checkout the documentation of your preferred database for
+  Be sure to check out the documentation of your preferred database for
   more information.
 ^
 
@@ -83,10 +83,10 @@ The adapter name for the SQL Adapter is always <mark>:sql</mark> which makes
 things easy; whereas connection strings are database driver specific. Connection
 strings tell the SQL Adapter which driver to use for the connection along with
 the port and host address of the database server. Connection strings can also
-be used to set most available options however it's generally better to keep
-the connection string short and focused on network routing. Additional options
-can be provided in a convenient hash structure or by named parameters on the
-configuration method signature.
+be used to set most of the available options, however it's generally better to
+keep the connection string short and focused on network routing. Additional
+options can be provided in a convenient hash structure or by named parameters
+on the configuration method signature.
 
 An example of this can be seen below:
 
@@ -182,7 +182,7 @@ The only supported structure for connecting to PostgreSQL databases is the
 Connection String URI format:
 
 ```
-'postgresql://[user[:password]@][host][:port][,...][/database][?param1=value1&...]'
+'postgres://[user[:password]@][host][:port][,...][/database][?param1=value1&...]'
 ```
 
 For more detailed information on connections strings see the PostgreSQL
@@ -594,7 +594,7 @@ to this type of database.
 ^
 
 For more information see 
-[Sequels SQLite](http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-sqlite)
+[Sequel's SQLite](http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-sqlite)
 documentation or for URI file formats see
 [URI Filenames in SQLite](https://www.sqlite.org/uri.html)
 
@@ -776,7 +776,7 @@ ones documented here.
 
 These drivers have not been documented because their use is fairly uncommon
 however they should work and documentation for connecting with each of these
-drivers can be found in Sequels 
+drivers can be found in Sequel's 
 [Opening Databases](http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html)
 document.
 
@@ -786,7 +786,7 @@ document.
 
 In a JRuby environment, it's best to use the `JDBC` driver available to
 you via the Java SDK. Support for databases in JRuby is handled via
-Sequels JDBC sub adapters. 
+Sequel's JDBC sub adapters. 
 
 A list of supported databases can be found below along with additional
 requirements:
@@ -820,7 +820,7 @@ jdbc:sqlite::memory
 ```
 
 For more information see 
-[Sequels JDBC](http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-jdbc+)
+[Sequel's JDBC](http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-jdbc+)
 and
 [Java SE - Database](http://www.oracle.com/technetwork/java/javase/jdbc/index.html)
 documentation


### PR DESCRIPTION
This is a collection of documentation corrections I gathered while going over the "Learn" guides.

The only one that might not speak for itself is the change from `postgresql://` to `postgres://`, which I made not because `postgresql://` was incorrect, but because the other Postgres URLs on that page all use `postgres://`, and the Sequel documentation as well, so I thought it would be more consistent.