### PR TITLE
Fix links missing target class component

### DIFF
--- a/lib/markdown_renderer.rb
+++ b/lib/markdown_renderer.rb
@@ -56,6 +56,7 @@ class MarkdownRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
       )
     else
       content = ['ROM', *klass, target].join('::')
+      path    = [*path, target].join("/")
 
       link(
         config.api_url_template % { project: project, path: path },


### PR DESCRIPTION
In https://github.com/rom-rb/rom-rb.org/pull/226 I made a mistake and forgot to add `target` to the link href. Sorry for that.