### PR TITLE
Add more info about db:setup task

### DIFF
--- a/source/4.0/learn/sql/migrations.html.md
+++ b/source/4.0/learn/sql/migrations.html.md
@@ -19,6 +19,7 @@ require 'rom/sql/rake_task'
 namespace :db do
   task :setup do
     # your ROM setup code
+    ROM::SQL::RakeSupport.env = ROM.container(:sql, 'postgres://localhost/rom')
   end
 end
 ```


### PR DESCRIPTION
Hi!

I spend a while trying to figure what should be in `db:setup`, until I found that little comment in [rom-sql sources](https://github.com/rom-rb/rom-sql/blob/master/lib/rom/sql/tasks/migration_tasks.rake#L19):
```ruby
        # Global environment used for running migrations. You normally
        # set in the `db:setup` task with `ROM::SQL::RakeSupport.env = ROM.container(...)`
        # or something similar.
```

Can we add a line about `ROM::SQL::RakeSupport.env` to the migration guide?