### PR TITLE
Remove require pure_ruby & add docs for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,26 @@ Official Ruby Object Mapper website.
    ```shell
    bundle exec middleman build
    ```
+
+ ## Windows Instructions
+ If you're getting the following error:
+ 
+ ```
+ Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'
+ ```
+ 
+ or features such as Live Reload are not working then it's because the
+ C extension for eventmachine needs to be installed.
+ 
+ ```
+ gem uninstall eventmachine
+ ```
+ 
+ take note of the version being used. (At the time of writing '1.2.0.1')
+ 
+ ```
+ gem install eventmachine -v '[VERSION]' --platform=ruby
+ ```
+ 
+ If you have a proper environment with DevKit installed then eventmachine with its
+ C extension will be installed and everything will work fine.

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,3 @@
-require 'em/pure_ruby'
-
 # This is a monkey-patch to fix the problem with double-watching
 # symlinked directories
 WATCHED_PATHS = (


### PR DESCRIPTION
Eventmachines pure_ruby implementation is not needed on windows, but
bundler doesn't install the C exentions by default unless the user
is on the ruby platform.