### PR TITLE
[fix] Add association definition in has_many-through

### DIFF
--- a/source/4.0/learn/sql/associations.html.md
+++ b/source/4.0/learn/sql/associations.html.md
@@ -45,6 +45,7 @@ many-to-many association type.
 class Users < ROM::Relation[:sql]
   schema(infer: true) do
     associations do
+      has_many :users_tasks
       has_many :tasks, through: :users_tasks
     end
   end


### PR DESCRIPTION
Without this definition ROM raise `ROM::ElementNotFoundError`