### PR TITLE
Added documentation for RakeSupport.env config + file-based migrations

### DIFF
--- a/source/4.0/learn/sql/migrations.html.md
+++ b/source/4.0/learn/sql/migrations.html.md
@@ -76,3 +76,4 @@ migration.apply(gateway.connection, :up)
 ## Learn more
 
 * [api::rom-sql::SQL](Migration)
+* [Sequel migration documentation](https://github.com/jeremyevans/sequel/blob/master/doc/schema_modification.rdoc)

--- a/source/4.0/learn/sql/migrations.html.md
+++ b/source/4.0/learn/sql/migrations.html.md
@@ -19,6 +19,8 @@ require 'rom/sql/rake_task'
 namespace :db do
   task :setup do
     # your ROM setup code
+    # Usually something like this:
+    # ROM::SQL::RakeSupport.env = ROM.container(...)
   end
 end
 ```
@@ -27,13 +29,32 @@ The following tasks are available:
 
 * `rake db:create_migration[create_users]` - create migration file under
   `db/migrate`
-* `rake db:migrate` - runs migrations
+* `rake db:migrate` - runs migrations located in `db/migrate`
 * `rake db:clean` - removes all tables
 * `rake db:reset` - removes all tables and re-runs migrations
 
+### File-based migrations
+
+Migrations created with a command such as `rake db:create_migration[create_users]` will be placed at under the `db/migrate` folder at the root of your project.
+
+These migrations should follow this syntax:
+
+```ruby
+ROM::SQL.migration do
+  change do
+    create_table :users do
+      primary_key :id
+      column :name, String, null: false
+    end
+  end
+end
+```
+
+Filenames for migrations begin with the datestamp following this convention `date +%Y%m%d%H%M%S`. That is: 4 digits for the year, followed by 2 digits for the month, day, hour, minute and second the migration was created. This provides an order to the migrations so you can migrate and build your database up piece-by-piece in the same order every time.
+
 ### Using Gateway Migration Interface
 
-You can use migrations using gateway's interface:
+You can also use migrations by using a gateway's interface:
 
 ``` ruby
 rom = ROM.container(:sql, 'postgres://localhost/rom')
@@ -51,3 +72,7 @@ end
 
 migration.apply(gateway.connection, :up)
 ```
+
+## Learn more
+
+* [api::rom-sql::SQL](Migration)


### PR DESCRIPTION
I was pairing with @sebpearce today and we talked about this migrations page. A couple of things stood out:

1. It wasn't very clear what "your ROM setup code" meant in the `db:setup` Rake task example.
2. There wasn't any documentation about using file-based migrations.

So we thought it'd be a good thing to contribute back both of those things :) :tada:

## ROM Setup Code

I'm basing the changes here on what I found in the migration rake task file [here](https://github.com/rom-rb/rom-sql/blob/e41b4c0e533946d1cb43ef9fda1f1fd1e164846b/lib/rom/sql/tasks/migration_tasks.rake#L18-L22). I don't know 100% if this is the right thing, but I think it'll at least give people a general idea of what should go there. For instance, our `db:setup` task is [defined like this](https://github.com/sebpearce/cycad/blob/master/Rakefile#L7-L13). It works for us :)


## File-based migrations

The documentation here is valuable I think. If you've got experience with Rails then you _probably_ know about its `db/migrate` directory and its naming conventions. So I wanted to make that crystal clear on this page that you can use file-based migrations as well as the gateway migration syntax that still exists on this page.

:heart:

