### PR TITLE
Allow specifying timestamps manually when using mappers

### DIFF
--- a/source/3.0/learn/repositories/changesets.html.md
+++ b/source/3.0/learn/repositories/changesets.html.md
@@ -73,6 +73,8 @@ and in addition to that we have:
 * `:add_timestamps`–sets `created_at` and `updated_at` timestamps (don't forget to add those fields to the table in case of using `rom-sql`)
 * `:touch`–sets `updated_at` timestamp
 
+You can override the timestamps by simply setting them in the input data.
+
 ### Pre-configured mapping
 
 If you want to process data before sending them to be persisted, you can define


### PR DESCRIPTION
Regarding [this pull request](https://github.com/rom-rb/rom/pull/484). Let me know if there's a better way to word the changes!