### PR TITLE
Fix typo in code block Learn/SQL/Schemas/Coercions

### DIFF
--- a/source/4.0/learn/sql/schemas.html.md
+++ b/source/4.0/learn/sql/schemas.html.md
@@ -37,9 +37,9 @@ class Posts < ROM::Relation[:sql]
   end
 end
 
-id = users.insert(title: 'Hello World', status: :draft)
+id = Posts.insert(title: 'Hello World', status: :draft)
 
-users.by_pk(1).one
+Posts.by_pk(1).one
 # => {:id => 1, :title => "Hello World", status: :draft }
 ```
 


### PR DESCRIPTION
Hey, small improvement to documentation.
```ruby
class Posts < ROM::Relation[:sql]
  schema(infer: true) do
    attribute :status, Types::String, read: Types.Constructor(Symbol, &:to_sym)
  end
end

id = Posts.insert(title: 'Hello World', status: :draft)

Posts.by_pk(1).one
```
instead of `users`-relation
