### PR TITLE
Fix invalid link in learn/core/schemas/index view

### DIFF
--- a/docs/4.0/learn/core/schemas/index.html
+++ b/docs/4.0/learn/core/schemas/index.html
@@ -141,7 +141,7 @@ low-level constraints.</p>
 <span class="k">end</span>
 </code></pre>
 <p>Now when you persist data using <a href="/4.0/learn/repositories">repositories</a> or
-<a href="/4.0/learn/advanced/custom-commands">custom commands</a>, your schema will be used
+<a href="/4.0/learn/core/commands/">commands</a>, your schema will be used
 to process the input data, and our <code>:id</code> value will be handled by the <code>UUID</code> type.</p>
 <h2 id="using-code-read-code-types" class="hd"><a name="using-code-read-code-types" class="anchor" href="#using-code-read-code-types">       <svg aria-hidden="true" height="16" width="16" version="1.1" viewBox="0 0 16 16">
        <path d="M4 9h1v1h-1c-1.5 0-3-1.69-3-3.5s1.55-3.5 3-3.5h4c1.45 0 3 1.69 3 3.5 0 1.41-0.91 2.72-2 3.25v-1.16c0.58-0.45 1-1.27 1-2.09 0-1.28-1.02-2.5-2-2.5H4c-0.98 0-2 1.22-2 2.5s1 2.5 2 2.5z m9-3h-1v1h1c1 0 2 1.22 2 2.5s-1.02 2.5-2 2.5H9c-0.98 0-2-1.22-2-2.5 0-0.83 0.42-1.64 1-2.09v-1.16c-1.09 0.53-2 1.84-2 3.25 0 1.81 1.55 3.5 3 3.5h4c1.45 0 3-1.69 3-3.5s-1.5-3.5-3-3.5z"></path>


### PR DESCRIPTION
Here is a link to [Using `write` types](http://rom-rb.org/4.0/learn/core/schemas/#using-code-write-code-types) section where this link is