### PR TITLE
Add broken links finder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'nokogiri'
 gem 'slim'
 gem 'redcarpet'
 
+# Checks html markup
+gem 'html-proofer'
+
 group :development do
   gem 'pry-byebug'
   gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colorize (0.8.1)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.5)
@@ -24,6 +25,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.0.1)
     eventmachine (1.2.0.1-x64-mingw32)
     execjs (2.7.0)
@@ -36,6 +39,15 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (3.5.6)
+    html-proofer (3.10.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.9)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.14.0)
@@ -43,6 +55,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
+    mercenary (0.3.6)
     method_source (0.9.0)
     middleman (4.2.1)
       coffee-script (~> 2.2)
@@ -125,16 +138,20 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    yell (2.2.0)
 
 PLATFORMS
   ruby
   x64-mingw32
 
 DEPENDENCIES
+  html-proofer
   middleman (~> 4.0)
   middleman-blog
   middleman-livereload

--- a/config.rb
+++ b/config.rb
@@ -209,3 +209,18 @@ begin
   require 'pry-byebug'
 rescue LoadError
 end
+
+# Find broken links in documentation
+require 'html-proofer'
+
+after_build do
+  begin
+    configuration = {
+      assume_extension: true,
+      allow_hash_href:  true, # allow `#` in href
+      empty_alt_ignore: true  # allow blank alt tag in images
+    }
+    HTMLProofer.check_directory(config[:build_dir], configuration).run
+  rescue RuntimeError
+  end
+end


### PR DESCRIPTION
While reading documentation there are a lot of broken link(404). I've decided to add kind of linter for build process. Now when you run `bundle exec middleman build` HtmlProofer checks all the links in documentation. Here is the output of linter:
 
- docs/3.0/learn/advanced/index.html
  *  internally linking to /3.0/learn/advanced/custom_commands, which does not exist (line 11)
     <a href="/3.0/learn/advanced/custom_commands">Custom Commands</a>
- docs/3.0/learn/kafka/index.html
  *  linking to internal hash #relation that does not exist (line 29)
     <a href="#relation">relation</a>
- docs/3.0/learn/repositories/changeset-transactions/index.html
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset/Stateful#associate-instance_method failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository#transaction-instance_method failed: 404 No error
- docs/3.0/learn/repositories/changesets/index.html
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset/Associated failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset/Create failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset/Delete failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Changeset/Update failed: 404 No error
- docs/3.0/learn/repositories/reading-aggregates/index.html
  *  External link http://www.rubydoc.info/gems/rom-repository/ROM/Repository/RelationProxy/Combine failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository/RelationProxy#combine-instance_method failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository/RelationProxy#combine_children-instance_method failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository/RelationProxy#combine_parents-instance_method failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository/RelationProxy#wrap_parent-instance_method failed: 404 No error
  *  External link https://api.rom-rb.org/rom-repository/ROM/Repository/Root#aggregate-instance_method failed: 404 No error
  *  internally linking to /3.0/learn/getting-started/block-style-setup, which does not exist (line 27)
     <a href="/3.0/learn/getting-started/block-style-setup">block-style setup</a>
- docs/4.0/learn/advanced/explicit-setup/index.html
  *  External link http://rom-rb.org/introduction/glossary/#dataset failed: 404 No error
  *  internally linking to /4.0/glossary/#dataset, which does not exist (line 100)
     <a href="/4.0/glossary/#dataset">Dataset</a>
  *  trying to find hash of /4.0/glossary/#dataset, but /Users/a.koval/dev/rom-rb.org/docs/4.0/glossary does not exist (line 100)
     <a href="/4.0/glossary/#dataset">Dataset</a>
- docs/4.0/learn/advanced/index.html
  *  internally linking to /4.0/learn/advances/how-to-build-an-adapter, which does not exist (line 9)
     <a href="/4.0/learn/advances/how-to-build-an-adapter">Custom Adapter</a>
- docs/4.0/learn/core/schemas/index.html
  *  internally linking to /4.0/learn/advanced/custom-commands, which does not exist (line 144)
     <a href="/4.0/learn/advanced/custom-commands">custom commands</a>
- docs/4.0/learn/introduction/active-record/index.html
  *  internally linking to /4.0/learn/getting-started/setup-sql, which does not exist (line 44)
     <a href="/4.0/learn/getting-started/setup-sql">Setup DSL</a>
- docs/4.0/learn/kafka/index.html
  *  External link http://rom-rb.org/guides/basics/commands/ failed: 404 No error
  *  External link http://rom-rb.org/guides/basics/mappers failed: 404 No error
  *  External link http://rom-rb.org/guides/basics/relations/ failed: 404 No error
  *  External link http://rom-rb.org/guides/basics/setup failed: 404 No error
  *  linking to internal hash #relation that does not exist (line 29)
     <a href="#relation">relation</a>
- docs/4.0/learn/sql/associations/index.html
  *  External link https://api.rom-rb.org/rom-sql/ROM/SQL/Association/ManyToMany failed: 404 No error
  *  External link https://api.rom-rb.org/rom-sql/ROM/SQL/Association/ManyToOne failed: 404 No error
  *  External link https://api.rom-rb.org/rom-sql/ROM/SQL/Association/OneToMany failed: 404 No error
  *  External link https://api.rom-rb.org/rom-sql/ROM/SQL/Association/OneToOne failed: 404 No error
- docs/4.0/learn/sql/index.html
  *  linking to internal hash #connection-to-a-database that does not exist (line 11)
     <a href="#connection-to-a-database">Connecting to a Database</a>
- docs/5.0/learn/advanced/explicit-setup/index.html
  *  internally linking to /5.0/glossary/#dataset, which does not exist (line 100)
     <a href="/5.0/glossary/#dataset">Dataset</a>
  *  trying to find hash of /5.0/glossary/#dataset, but /Users/a.koval/dev/rom-rb.org/docs/5.0/glossary does not exist (line 100)
     <a href="/5.0/glossary/#dataset">Dataset</a>
- docs/5.0/learn/core/schemas/index.html
  *  internally linking to /5.0/learn/advanced/custom-commands, which does not exist (line 144)
     <a href="/5.0/learn/advanced/custom-commands">custom commands</a>
- docs/5.0/learn/introduction/active-record/index.html
  *  internally linking to /5.0/learn/getting-started/setup-sql, which does not exist (line 44)
     <a href="/5.0/learn/getting-started/setup-sql">Setup DSL</a>
- docs/5.0/learn/kafka/index.html
  *  linking to internal hash #relation that does not exist (line 29)
     <a href="#relation">relation</a>
- docs/5.0/learn/sql/index.html
  *  linking to internal hash #connection-to-a-database that does not exist (line 11)
     <a href="#connection-to-a-database">Connecting to a Database</a>
- docs/blog/page/2/index.html
  *  internally linking to learn/core/changesets/, which does not exist (line 232)
     <a href="learn/core/changesets/">Changeset documentation for more information</a>
- docs/blog/page/4/index.html
  *  internally linking to /learn/repositories/changesets, which does not exist (line 73)
     <a href="/learn/repositories/changesets">the user documentation</a>
- docs/blog/page/5/index.html
  *  internally linking to /blog/2015/11/24/first-beta-of-rom-1-0-0-has-been-released/, which does not exist (line 9)
     <a href="/blog/2015/11/24/first-beta-of-rom-1-0-0-has-been-released/">previous announcement</a>
- docs/blog/page/8/index.html
  *  internally linking to /blog/2015/03/23/rom-0-6-0-released/, which does not exist (line 7)
     <a href="/blog/2015/03/23/rom-0-6-0-released/">improvements and API changes in 0.6.0</a>
- docs/blog/page/9/index.html
  *  internally linking to /introduction, which does not exist (line 46)
     <a href="/introduction">introductions</a>
  *  internally linking to /introduction, which does not exist (line 51)
     <a href="/introduction">introductions</a>
  *  internally linking to /introduction/activerecord, which does not exist (line 53)
     <a href="/introduction/activerecord">ActiveRecord</a>
  *  internally linking to /introduction/why, which does not exist (line 53)
     <a href="/introduction/why">Why ROM</a>
  *  internally linking to /tutorials, which does not exist (line 46)
     <a href="/tutorials">tutorials</a>
  *  internally linking to /tutorials, which does not exist (line 63)
     <a href="/tutorials">tutorials</a>
  *  internally linking to /tutorials/rails, which does not exist (line 59)
     <a href="/tutorials/rails">ROM and Rails</a>
  *  internally linking to /tutorials/rails, which does not exist (line 32)
     <a href="/tutorials/rails">Rails Tutorial</a>
- docs/blog/rom-0-5-0-released/index.html
  *  External link https://github.com/solnic/rom-demo failed: 404 No error
  *  internally linking to /introduction, which does not exist (line 46)
     <a href="/introduction">introductions</a>
  *  internally linking to /introduction, which does not exist (line 51)
     <a href="/introduction">introductions</a>
  *  internally linking to /introduction/activerecord, which does not exist (line 53)
     <a href="/introduction/activerecord">ActiveRecord</a>
  *  internally linking to /introduction/why, which does not exist (line 53)
     <a href="/introduction/why">Why ROM</a>
  *  internally linking to /tutorials, which does not exist (line 63)
     <a href="/tutorials">tutorials</a>
  *  internally linking to /tutorials, which does not exist (line 46)
     <a href="/tutorials">tutorials</a>
  *  internally linking to /tutorials/rails, which does not exist (line 59)
     <a href="/tutorials/rails">ROM and Rails</a>
  *  internally linking to /tutorials/rails, which does not exist (line 32)
     <a href="/tutorials/rails">Rails Tutorial</a>
- docs/blog/rom-0-6-0-released/index.html
  *  External link http://rom-rb.org/tutorials/todo-app-with-rails/ failed: 404 No error
- docs/blog/rom-0-6-1-released/index.html
  *  External link https://github.com/rom-rb/rom-lotus failed: 404 No error
  *  External link https://github.com/rom-rb/rom-lotus/blob/master/CHANGELOG.md failed: 404 No error
  *  internally linking to /blog/2015/03/23/rom-0-6-0-released/, which does not exist (line 7)
     <a href="/blog/2015/03/23/rom-0-6-0-released/">improvements and API changes in 0.6.0</a>
- docs/blog/rom-0-7-0-released/index.html
  *  External link http://waffle.io/ failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Couldn't resolve host name
  *  External link http://waffle.io/rom-rb/rom failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Couldn't resolve host name
- docs/blog/rom-0-9-0-released/index.html
  *  External link http://rom-rb.org/guides/basics/mappers/ failed: 404 No error
  *  External link http://rom-rb.org/guides/basics/repositories/ failed: 404 No error
  *  External link https://github.com/rom-rb/rom-lotus/blob/master/CHANGELOG.md#v020-2015-08-19 failed: 404 No error
- docs/blog/rom-1-0-0-rc-released/index.html
  *  internally linking to /blog/2015/11/24/first-beta-of-rom-1-0-0-has-been-released/, which does not exist (line 9)
     <a href="/blog/2015/11/24/first-beta-of-rom-1-0-0-has-been-released/">previous announcement</a>
- docs/blog/rom-2-0-0-released/index.html
  *  internally linking to /learn/repositories/changesets, which does not exist (line 73)
     <a href="/learn/repositories/changesets">the user documentation</a>
- docs/blog/rom-3-0-released/index.html
  *  External link http://rom-rb.org/learn/repositories/changesets/ failed: 404 No error
  *  External link http://rom-rb.org/learn/repositories/custom-changesets/ failed: 404 No error
- docs/blog/rom-4-0-released/index.html
  *  External link https://github.com/rom-rb/rom/blob/master/mapper/CHANGELOG.md failed: 404 No error
  *  internally linking to learn/core/changesets/, which does not exist (line 138)
     <a href="learn/core/changesets/">Changeset documentation for more information</a>
- docs/blog/tags/announcement/page/3/index.html
  *  internally linking to /blog/2015/03/23/rom-0-6-0-released/, which does not exist (line 13)
     <a href="/blog/2015/03/23/rom-0-6-0-released/">improvements and API changes in 0.6.0</a>
- docs/blog/tags/release/page/2/index.html
  *  internally linking to /blog/2015/03/23/rom-0-6-0-released/, which does not exist (line 13)
     <a href="/blog/2015/03/23/rom-0-6-0-released/">improvements and API changes in 0.6.0</a>
- docs/guides/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/guides/index.html.md failed: 404 No error
- docs/guides/sql-quick-start/connecting-to-existing-database/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/guides/sql-quick-start/connecting-to-existing-database.html.md failed: 404 No error
- docs/guides/sql-quick-start/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/guides/sql-quick-start/index.html.md failed: 404 No error
- docs/index.html
  *  External link https://ruby-lang.org/ failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: SSL peer certificate or SSH remote key was not OK
- docs/learn/advanced/explicit-setup/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/advanced/explicit-setup.html.md failed: 404 No error
  *  internally linking to /5.0/glossary/#dataset, which does not exist (line 100)
     <a href="/5.0/glossary/#dataset">Dataset</a>
  *  trying to find hash of /5.0/glossary/#dataset, but /Users/a.koval/dev/rom-rb.org/docs/5.0/glossary does not exist (line 100)
     <a href="/5.0/glossary/#dataset">Dataset</a>
- docs/learn/advanced/how-to-build-an-adapter/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/advanced/how-to-build-an-adapter.html.md failed: 404 No error
- docs/learn/advanced/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/advanced/index.html.md failed: 404 No error
- docs/learn/core/associations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/associations.html.md failed: 404 No error
- docs/learn/core/changesets/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/changesets.html.md failed: 404 No error
- docs/learn/core/combines/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/combines.html.md failed: 404 No error
- docs/learn/core/commands/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/commands.html.md failed: 404 No error
- docs/learn/core/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/index.html.md failed: 404 No error
- docs/learn/core/mappers/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/mappers.html.md failed: 404 No error
- docs/learn/core/relations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/relations.html.md failed: 404 No error
- docs/learn/core/schemas/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/schemas.html.md failed: 404 No error
  *  internally linking to /5.0/learn/advanced/custom-commands, which does not exist (line 144)
     <a href="/5.0/learn/advanced/custom-commands">custom commands</a>
- docs/learn/core/structs/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/core/structs.html.md failed: 404 No error
- docs/learn/getting-started/core-concepts/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/getting-started/core-concepts.html.md failed: 404 No error
- docs/learn/getting-started/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/getting-started/index.html.md failed: 404 No error
- docs/learn/getting-started/rails-setup/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/getting-started/rails-setup.html.md failed: 404 No error
- docs/learn/getting-started/setup-dsl/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/getting-started/setup-dsl.html.md failed: 404 No error
- docs/learn/glossary/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/glossary/index.html.md failed: 404 No error
- docs/learn/http/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/http/index.html.md failed: 404 No error
- docs/learn/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/index.html.slim failed: 404 No error
- docs/learn/introduction/active-record/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/introduction/active-record.html.md failed: 404 No error
  *  internally linking to /5.0/learn/getting-started/setup-sql, which does not exist (line 44)
     <a href="/5.0/learn/getting-started/setup-sql">Setup DSL</a>
- docs/learn/introduction/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/introduction/index.html.md failed: 404 No error
- docs/learn/kafka/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/kafka/index.html.md failed: 404 No error
  *  linking to internal hash #relation that does not exist (line 29)
     <a href="#relation">relation</a>
- docs/learn/repositories/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/repositories/index.html.md failed: 404 No error
- docs/learn/repositories/quick-start/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/repositories/quick-start.html.md failed: 404 No error
- docs/learn/repositories/reading-aggregates/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/repositories/reading-aggregates.html.md failed: 404 No error
- docs/learn/repositories/reading-simple-objects/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/repositories/reading-simple-objects.html.md failed: 404 No error
- docs/learn/repositories/writing-aggregates/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/repositories/writing-aggregates.html.md failed: 404 No error
- docs/learn/sql/advanced-pg-support/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/advanced-pg-support.html.md failed: 404 No error
- docs/learn/sql/associations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/associations.html.md failed: 404 No error
- docs/learn/sql/attributes/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/attributes.html.md failed: 404 No error
- docs/learn/sql/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/index.html.md failed: 404 No error
  *  linking to internal hash #connection-to-a-database that does not exist (line 11)
     <a href="#connection-to-a-database">Connecting to a Database</a>
- docs/learn/sql/joins/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/joins.html.md failed: 404 No error
- docs/learn/sql/migrations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/migrations.html.md failed: 404 No error
- docs/learn/sql/queries/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/queries.html.md failed: 404 No error
- docs/learn/sql/relations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/relations.html.md failed: 404 No error
- docs/learn/sql/schemas/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/schemas.html.md failed: 404 No error
- docs/learn/sql/transactions/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/learn/sql/transactions.html.md failed: 404 No error
- docs/next/guides/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/guides/index.html.md failed: 404 No error
- docs/next/guides/sql-quick-start/connecting-to-existing-database/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/guides/sql-quick-start/connecting-to-existing-database.html.md failed: 404 No error
- docs/next/guides/sql-quick-start/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/guides/sql-quick-start/index.html.md failed: 404 No error
- docs/next/learn/advanced/explicit-setup/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/advanced/explicit-setup.html.md failed: 404 No error
  *  internally linking to /next/glossary/#dataset, which does not exist (line 100)
     <a href="/next/glossary/#dataset">Dataset</a>
  *  trying to find hash of /next/glossary/#dataset, but /Users/a.koval/dev/rom-rb.org/docs/next/glossary does not exist (line 100)
     <a href="/next/glossary/#dataset">Dataset</a>
- docs/next/learn/advanced/how-to-build-an-adapter/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/advanced/how-to-build-an-adapter.html.md failed: 404 No error
- docs/next/learn/advanced/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/advanced/index.html.md failed: 404 No error
- docs/next/learn/core/associations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/associations.html.md failed: 404 No error
- docs/next/learn/core/changesets/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/changesets.html.md failed: 404 No error
- docs/next/learn/core/combines/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/combines.html.md failed: 404 No error
- docs/next/learn/core/commands/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/commands.html.md failed: 404 No error
- docs/next/learn/core/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/index.html.md failed: 404 No error
- docs/next/learn/core/mappers/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/mappers.html.md failed: 404 No error
- docs/next/learn/core/relations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/relations.html.md failed: 404 No error
- docs/next/learn/core/schemas/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/schemas.html.md failed: 404 No error
  *  internally linking to /next/learn/advanced/custom-commands, which does not exist (line 144)
     <a href="/next/learn/advanced/custom-commands">custom commands</a>
- docs/next/learn/core/structs/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/core/structs.html.md failed: 404 No error
- docs/next/learn/getting-started/core-concepts/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/getting-started/core-concepts.html.md failed: 404 No error
- docs/next/learn/getting-started/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/getting-started/index.html.md failed: 404 No error
- docs/next/learn/getting-started/rails-setup/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/getting-started/rails-setup.html.md failed: 404 No error
- docs/next/learn/getting-started/setup-dsl/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/getting-started/setup-dsl.html.md failed: 404 No error
- docs/next/learn/glossary/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/glossary/index.html.md failed: 404 No error
- docs/next/learn/http/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/http/index.html.md failed: 404 No error
- docs/next/learn/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/index.html.slim failed: 404 No error
- docs/next/learn/introduction/active-record/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/introduction/active-record.html.md failed: 404 No error
  *  internally linking to /next/learn/getting-started/setup-sql, which does not exist (line 44)
     <a href="/next/learn/getting-started/setup-sql">Setup DSL</a>
- docs/next/learn/introduction/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/introduction/index.html.md failed: 404 No error
- docs/next/learn/kafka/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/kafka/index.html.md failed: 404 No error
  *  linking to internal hash #relation that does not exist (line 29)
     <a href="#relation">relation</a>
- docs/next/learn/repositories/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/repositories/index.html.md failed: 404 No error
- docs/next/learn/repositories/quick-start/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/repositories/quick-start.html.md failed: 404 No error
- docs/next/learn/repositories/reading-aggregates/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/repositories/reading-aggregates.html.md failed: 404 No error
- docs/next/learn/repositories/reading-simple-objects/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/repositories/reading-simple-objects.html.md failed: 404 No error
- docs/next/learn/repositories/writing-aggregates/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/repositories/writing-aggregates.html.md failed: 404 No error
- docs/next/learn/sql/advanced-pg-support/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/advanced-pg-support.html.md failed: 404 No error
- docs/next/learn/sql/associations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/associations.html.md failed: 404 No error
- docs/next/learn/sql/attributes/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/attributes.html.md failed: 404 No error
- docs/next/learn/sql/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/index.html.md failed: 404 No error
  *  linking to internal hash #connection-to-a-database that does not exist (line 11)
     <a href="#connection-to-a-database">Connecting to a Database</a>
- docs/next/learn/sql/joins/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/joins.html.md failed: 404 No error
- docs/next/learn/sql/migrations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/migrations.html.md failed: 404 No error
- docs/next/learn/sql/queries/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/queries.html.md failed: 404 No error
- docs/next/learn/sql/relations/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/relations.html.md failed: 404 No error
- docs/next/learn/sql/schemas/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/schemas.html.md failed: 404 No error
- docs/next/learn/sql/transactions/index.html
  *  External link https://github.com/rom-rb/rom-rb.org/blob/master/source/next/learn/sql/transactions.html.md failed: 404 No error
- docs/status/index.html
  *  External link https://codeclimate.com/github/rom-rb/rom-couchdb failed: 404 No error
  *  External link https://codeclimate.com/github/rom-rb/rom-couchdb/badges/coverage.svg failed: 404 No error
  *  External link https://codeclimate.com/github/rom-rb/rom-couchdb/badges/gpa.svg failed: 404 No error
  *  External link https://codeclimate.com/github/rom-rb/rom-roda failed: 404 No error
  *  External link https://codeclimate.com/github/rom-rb/rom-roda/badges/coverage.svg failed: 404 No error
  *  External link https://codeclimate.com/github/rom-rb/rom-roda/badges/gpa.svg failed: 404 No error
  *  External link https://rubygems.org/gems/rom-influxdb failed: 404 No error
  *  External link https://rubygems.org/gems/rom-redis failed: 404 No error