### PR TITLE
Fix typo in HTTP adapter example

### DIFF
--- a/source/5.0/learn/http/index.html.md
+++ b/source/5.0/learn/http/index.html.md
@@ -58,7 +58,7 @@ Here's an example how you could define a relation to fetch organizations from Gi
 ```ruby
 module GitHub
   module Resources
-    class Organizations < ROM::Relations[:http]
+    class Organizations < ROM::Relation[:http]
       schema(:orgs) do
         attribute :id, Types::JSON::Integer
         attribute :name, Types::JSON::String


### PR DESCRIPTION
Class name is supposed to be `Relation`, not `Relations`