### PR TITLE
Replace gitter chat room mention with zulip

### DIFF
--- a/source/3.0/learn/adapters/adapter/cassandra.md
+++ b/source/3.0/learn/adapters/adapter/cassandra.md
@@ -277,7 +277,7 @@ gateway.migrate path: "db/migrate", logger: logger, version: 20151231235959
 [CQL builder UPDATE wiki page]: https://github.com/nepalez/query_builder/wiki/UPDATE
 [CQL builder wiki]: https://github.com/nepalez/query_builder/wiki/Home
 [CQL builder]: https://github.com/nepalez/query_builder
-[ROM chatroom]: https://gitter.im/rom-rb/chat
+[ROM chatroom]: https://rom-rb.zulipchat.com
 [ROM project on Github]: https://github.com/rom-rb/rom
 [rom-cassandra]: https://github.com/rom-rb/rom-cassandra
 [ruby driver]: https://github.com/datastax/ruby-driver

--- a/source/3.0/learn/kafka/index.html.md
+++ b/source/3.0/learn/kafka/index.html.md
@@ -7,7 +7,7 @@ ROM supports [Apache Kafka][kafka] via [rom-kafka][rom-kafka] adapter, that is
 built on top of the [poseidon][poseidon] ruby driver.
 
 > Before v0.1.0 the adapter is still in alpha. If you find any inconsistency,
-> please feel free to ask your questions at the [ROM chatroom][rom-gitter] and
+> please feel free to ask your questions at the [ROM chatroom][rom-zulip] and
 > report issues [on github][rom-kafka].
 
 ## Intro
@@ -319,7 +319,7 @@ Mappers can be applied to relations and commands in a
 [poseidon]: https://github.com/bpot/poseidon
 [rom-commands]: http://rom-rb.org/guides/basics/commands/
 [rom-github]: https://github.com/rom-rb/rom
-[rom-gitter]: https://gitter.im/rom-rb/chat
+[rom-zulip]: https://rom-rb.zulipchat.com
 [rom-kafka]: https://github.com/rom-rb/rom-kafka
 [rom-mappers]: http://rom-rb.org/guides/basics/mappers
 [rom-relations]: http://rom-rb.org/guides/basics/relations/

--- a/source/4.0/learn/adapters/adapter/cassandra.md
+++ b/source/4.0/learn/adapters/adapter/cassandra.md
@@ -277,7 +277,7 @@ gateway.migrate path: "db/migrate", logger: logger, version: 20151231235959
 [CQL builder UPDATE wiki page]: https://github.com/nepalez/query_builder/wiki/UPDATE
 [CQL builder wiki]: https://github.com/nepalez/query_builder/wiki/Home
 [CQL builder]: https://github.com/nepalez/query_builder
-[ROM chatroom]: https://gitter.im/rom-rb/chat
+[ROM chatroom]: https://rom-rb.zulipchat.com
 [ROM project on Github]: https://github.com/rom-rb/rom
 [rom-cassandra]: https://github.com/rom-rb/rom-cassandra
 [ruby driver]: https://github.com/datastax/ruby-driver

--- a/source/4.0/learn/kafka/index.html.md
+++ b/source/4.0/learn/kafka/index.html.md
@@ -7,7 +7,7 @@ ROM supports [Apache Kafka][kafka] via [rom-kafka][rom-kafka] adapter, that is
 built on top of the [poseidon][poseidon] ruby driver.
 
 > Before v0.1.0 the adapter is still in alpha. If you find any inconsistency,
-> please feel free to ask your questions at the [ROM chatroom][rom-gitter] and
+> please feel free to ask your questions at the [ROM chatroom][rom-zulip] and
 > report issues [on github][rom-kafka].
 
 ## Intro
@@ -319,7 +319,7 @@ Mappers can be applied to relations and commands in a
 [poseidon]: https://github.com/bpot/poseidon
 [rom-commands]: http://rom-rb.org/guides/basics/commands/
 [rom-github]: https://github.com/rom-rb/rom
-[rom-gitter]: https://gitter.im/rom-rb/chat
+[rom-zulip]: https://rom-rb.zulipchat.com
 [rom-kafka]: https://github.com/rom-rb/rom-kafka
 [rom-mappers]: http://rom-rb.org/guides/basics/mappers
 [rom-relations]: http://rom-rb.org/guides/basics/relations/

--- a/source/5.0/learn/adapters/adapter/cassandra.md
+++ b/source/5.0/learn/adapters/adapter/cassandra.md
@@ -277,7 +277,7 @@ gateway.migrate path: "db/migrate", logger: logger, version: 20151231235959
 [CQL builder UPDATE wiki page]: https://github.com/nepalez/query_builder/wiki/UPDATE
 [CQL builder wiki]: https://github.com/nepalez/query_builder/wiki/Home
 [CQL builder]: https://github.com/nepalez/query_builder
-[ROM chatroom]: https://gitter.im/rom-rb/chat
+[ROM chatroom]: https://rom-rb.zulipchat.com
 [ROM project on Github]: https://github.com/rom-rb/rom
 [rom-cassandra]: https://github.com/rom-rb/rom-cassandra
 [ruby driver]: https://github.com/datastax/ruby-driver

--- a/source/5.0/learn/kafka/index.html.md
+++ b/source/5.0/learn/kafka/index.html.md
@@ -7,7 +7,7 @@ ROM supports [Apache Kafka][kafka] via [rom-kafka][rom-kafka] adapter, that is
 built on top of the [poseidon][poseidon] ruby driver.
 
 ^INFO
-Before v0.1.0 the adapter is still in alpha. If you find any inconsistency, please feel free to ask your questions at the [ROM chatroom][rom-gitter] and report issues [on github][rom-kafka].
+Before v0.1.0 the adapter is still in alpha. If you find any inconsistency, please feel free to ask your questions at the [ROM chatroom][rom-zulip] and report issues [on github][rom-kafka].
 ^
 
 ## Intro
@@ -319,7 +319,7 @@ Mappers can be applied to relations and commands in a
 [poseidon]: https://github.com/bpot/poseidon
 [rom-commands]: http://rom-rb.org/guides/basics/commands/
 [rom-github]: https://github.com/rom-rb/rom
-[rom-gitter]: https://gitter.im/rom-rb/chat
+[rom-zulip]: https://rom-rb.zulipchat.com
 [rom-kafka]: https://github.com/rom-rb/rom-kafka
 [rom-mappers]: http://rom-rb.org/guides/basics/mappers
 [rom-relations]: http://rom-rb.org/guides/basics/relations/

--- a/source/blog/2014-12-31-rom-0-5-0-released.html.md
+++ b/source/blog/2014-12-31-rom-0-5-0-released.html.md
@@ -150,7 +150,7 @@ back and tell us what you think. Like. Dislike. We want to hear it all.
 #### Tell us how you're using ROM
 
 You may already be building things with ROM and we'd love to hear about it. What
-are you making? How is it working for you?  What interfaces have you created to
+are you making? How is it working for you? What interfaces have you created to
 make common work easier? This feedback can greatly improve the project for
 everyone.
 
@@ -179,8 +179,7 @@ as well. Get it started and we'll all chip in.
 #### Find your own way
 
 We truly believe there are as many ways to help as there people. Take a look
-around, chat with us on [Gitter][chat] and get to it.
-
+around, chat with us on [Zulip][chat] and get to it.
 
 **Thanks for reading and here's to a great 2015!**
 
@@ -195,4 +194,4 @@ around, chat with us on [Gitter][chat] and get to it.
 [proj-transproc]: https://github.com/solnic/transproc
 [proj-rom-yaml]: https://github.com/rom-rb/rom-yaml
 [proj-rom-csv]: https://github.com/rom-rb/rom-csv
-[chat]: https://gitter.im/rom-rb/chat
+[chat]: https://rom-rb.zulipchat.com

--- a/source/blog/2015-03-23-rom-0-6-0-released.html.md
+++ b/source/blog/2015-03-23-rom-0-6-0-released.html.md
@@ -169,8 +169,7 @@ end
 
 The setup DSL works the same but you probably want to switch to class-based setup as it's easier to organize your code that way.
 
-Please let us know if you have any trouble with the upgrade on our [gitter](https://gitter.im/rom-rb/chat) channel or submit an issue describing problems you're having.
-
+Please let us know if you have any trouble with the upgrade on our [zulip](https://rom-rb.zulipchat.com) channel or submit an issue describing problems you're having.
 
 ## About 1.0.0
 

--- a/source/blog/2015-04-04-rom-0-6-1-released.html.md
+++ b/source/blog/2015-04-04-rom-0-6-1-released.html.md
@@ -150,7 +150,7 @@ Expect to hear more about this as the integration evolves.
 
 ## Upgrading to 0.6.1
 
-Please let us know if you have any trouble with the upgrade. Contact us directly via [Gitter](https://gitter.im/rom-rb/chat) or [submit an issue on GitHub](https://github.com/rom-rb/rom/issues) describing any problems you're having.
+Please let us know if you have any trouble with the upgrade. Contact us directly via [Zulip](https://rom-rb.zulipchat.com) or [submit an issue on GitHub](https://github.com/rom-rb/rom/issues) describing any problems you're having.
 
 ## Onwards to 0.7
 

--- a/source/blog/2015-08-19-rom-0-9-0-released.html.md
+++ b/source/blog/2015-08-19-rom-0-9-0-released.html.md
@@ -267,7 +267,7 @@ Please also remember that ROM is a project open for contributions and currently 
 
 All repositories now have their own issue trackers enabled on GitHub. If you find a bug, or have problems using ROM, please report an issue for a specific project. If you're not sure which project it relates to, just report it in the main [rom issue tracker](https://github.com/rom-rb/rom/issues), and we'll move it to the right place if needed.
 
-For any random questions and support requests you can talk to us on [gitter](http://gitter.im/rom-rb/chat).
+For any random questions and support requests you can talk to us on [zulip](https://rom-rb.zulipchat.com).
 
 <s>Last but not least - we're looking for help in setting up a Discourse instance on DigitalOcean to make it simpler for people to discuss things as an alternative to gitter.</s>
 

--- a/source/blog/2015-11-24-first-beta-of-rom-1-0-0-has-been-released.html.md
+++ b/source/blog/2015-11-24-first-beta-of-rom-1-0-0-has-been-released.html.md
@@ -225,7 +225,7 @@ end
 
 Please try out the beta releases and provide feedback. Once we are sure that it works for everybody we'll be able to push the first RC and hopefully follow-up with the final 1.0.0 release shortly after the RC. Other gems that are now released as betas will be bumped to final versions and depend on rom 1.0.0 final.
 
-The final release also means a major update of [rom-rb.org](http://rom-rb.org) along with a new set of documentation, guides and tutorials. This is still a work in progress and needs help, please [get in touch](https://gitter.im/rom-rb/chat) if you're interested in helping out.
+The final release also means a major update of [rom-rb.org](http://rom-rb.org) along with a new set of documentation, guides and tutorials. This is still a work in progress and needs help, please [get in touch](https://rom-rb.zulipchat.com) if you're interested in helping out.
 
 Once rom 1.0.0 is out there will be major focus on rom-sql and rom-repository. There's a plan to [improve query DSL](https://github.com/rom-rb/rom-sql/issues/48) in rom-sql and provide full CRUD interface for repositories that should be handy for simple applications.
 

--- a/source/blog/2015-12-28-rom-1-0-0-rc-released.html.md
+++ b/source/blog/2015-12-28-rom-1-0-0-rc-released.html.md
@@ -19,6 +19,6 @@ As part of this release other gems have been upgraded too:
 - rom-sql 0.7.0.rc1
 - rom-repository 0.2.0.rc1
 
-These are pre-releases which means you need to add them explicitly to your Gemfile. If you're having problem with upgrading [report an issue](https://github.com/rom-rb/rom/issues), ask for help on [gitter](https://gitter.im/rom-rb/chat) or post a message on [the forum](http://discourse.rom-rb.org).
+These are pre-releases which means you need to add them explicitly to your Gemfile. If you're having problem with upgrading [report an issue](https://github.com/rom-rb/rom/issues), ask for help on [zulip](https://rom-rb.zulipchat.com) or post a message on [the forum](http://discourse.rom-rb.org).
 
 The final version should be released on Wednesday, December 30th, unless we find some blocking issues which are hard to fix.

--- a/source/blog/2016-01-06-rom-1-0-0-released.html.md
+++ b/source/blog/2016-01-06-rom-1-0-0-released.html.md
@@ -104,8 +104,8 @@ can get in touch:
 * Report [an issue](https://github.com/rom-rb/rom/issues) on GitHub, preferably
   in the issue tracker for the specific rom project. If you're not sure which one
   it is - don't worry and report it in the main rom issue tracker
-* Ask for help in [the gitter channel](https://gitter.im/rom-rb/chat)
 * Post a message [on our forum](http://discourse.rom-rb.org)
+* Ask for help in [the zulip channel](https://rom-rb.zulipchat.com)
 
 If you've got feedback regarding documentation and/or the website, please report
 an issue in [the rom-rb.org](https://github.com/rom-rb/rom-rb.org/issues) repo.

--- a/source/blog/2017-01-30-rom-3-0-released.html.md
+++ b/source/blog/2017-01-30-rom-3-0-released.html.md
@@ -301,6 +301,6 @@ Special thanks go to (in no particular order):
 
 We have big plans for future releases, but hopefully we'll manage to provide more frequent, incremental improvements now that rom-sql and rom-repository are stable. More details will be revealed soon, stay tuned!
 
-I hope you'll find this release useful, if you have problems or any kind of feedback, please report issues or just [talk to us](https://gitter.im/rom-rb/chat).
+I hope you'll find this release useful, if you have problems or any kind of feedback, please report issues or just [talk to us](https://rom-rb.zulipchat.com).
 
 If you happen to attend [RubyConf AU](http://rubyconf.org.au) next week, be sure to say hi! :)

--- a/source/contribute.html.md
+++ b/source/contribute.html.md
@@ -16,7 +16,7 @@ Dive deeper into the ROM ecosystem by writing an adapter for a new data source.
 
 ## Community
 
-Join [the conversation on Gitter](https://gitter.im/rom-rb/chat) to discuss anything related to ROM.
+Join [the conversation on Zulip](https://rom-rb.zulipchat.com) to discuss anything related to ROM.
 
 Report bugs and offer feedback on features via [GitHub Issues](https://github.com/rom-rb/rom/issues).
 


### PR DESCRIPTION
Community has moved from gitter to zulip, this PR changes the links referencing the former with the latter