### PR TITLE
Update how-to-build-an-adapter - ROM.container

### DIFF
--- a/source/guides/adapters/how-to-build-an-adapter.html.md
+++ b/source/guides/adapters/how-to-build-an-adapter.html.md
@@ -317,7 +317,7 @@ configuration.register_command(CreateUser)
 configuration.register_command(UpdateUser)
 configuration.register_command(DeleteUser)
 
-rom = ROM.create_container(configuration)
+rom = ROM.container(configuration)
 
 create_users = rom.commands[:users][:create]
 update_user = rom.commands[:users][:update]


### PR DESCRIPTION
Change `ROM.create_container` to `ROM.container`:
```
undefined method `create_container' for ROM:Module (NoMethodError)
```

Even in this file other examples use `ROM.container` method.